### PR TITLE
pkgdev.tatt.template.sh: add workaround for --with-test-deps bug

### DIFF
--- a/pkgdev.tatt.template.sh
+++ b/pkgdev.tatt.template.sh
@@ -90,8 +90,12 @@ tatt_test_pkg() {
         # Do a first pass to avoid circular dependencies
         # --onlydeps should mean we're avoiding (too much) duplicate work
         USE="minimal -doc" tattoo_emerge "${1}" --onlydeps --quiet --oneshot --with-test-deps
+        # Run it again with --usepkg=n because of a --with-test-deps quirk (bug #639588)
+        USE="minimal -doc" tattoo_emerge "${1}" --onlydeps --quiet --oneshot --with-test-deps --usepkg=n
 
-        if ! tattoo_emerge "${1}" --onlydeps --quiet --oneshot --with-test-deps; then
+        tattoo_emerge "${1}" --onlydeps --quiet --oneshot --with-test-deps
+        # Run it again with --usepkg=n because of a --with-test-deps quirk (bug #639588)
+        if ! tattoo_emerge "${1}" --onlydeps --quiet --oneshot --with-test-deps --usepkg=n; then
             tatt_json_report_error "merging test dependencies failed"
             return 1
         fi

--- a/tester.py
+++ b/tester.py
@@ -99,7 +99,7 @@ async def test_run(writer: Callable[[Any], Any], bug_no: int) -> str:
         f'--template-file={pkgdev_template}',
         f"--logs-dir={str(logs_dir)}",
         "--emerge-opts=--autounmask-keep-keywords=y --autounmask-use=y --autounmask-continue --autounmask-write",
-        "--ignore-prefixes=elibc_,video_cards_,linguas_,python_targets_,python_single_target_,kdeenablefinal,test,debug,qemu_user_,qemu_softmmu_,libressl,static-libs,systemd,sdjournal,elogind,doc,ruby_targets_",
+        "--ignore-prefixes=elibc_,video_cards_,linguas_,python_targets_,python_single_target_,kdeenablefinal,test,debug,qemu_user_,qemu_softmmu_,libressl,static-libs,systemd,sdjournal,elogind,doc,ruby_targets_,default-libcxx",
     )
     if key := bugs_fetcher.read_api_key():
         args += (f'--api-key={key}', )

--- a/tester.py
+++ b/tester.py
@@ -99,7 +99,7 @@ async def test_run(writer: Callable[[Any], Any], bug_no: int) -> str:
         f'--template-file={pkgdev_template}',
         f"--logs-dir={str(logs_dir)}",
         "--emerge-opts=--autounmask-keep-keywords=y --autounmask-use=y --autounmask-continue --autounmask-write",
-        "--ignore-prefixes=elibc_,video_cards_,linguas_,python_targets_,python_single_target_,kdeenablefinal,test,debug,qemu_user_,qemu_softmmu_,libressl,static-libs,systemd,sdjournal,eloginid,doc,ruby_targets_",
+        "--ignore-prefixes=elibc_,video_cards_,linguas_,python_targets_,python_single_target_,kdeenablefinal,test,debug,qemu_user_,qemu_softmmu_,libressl,static-libs,systemd,sdjournal,elogind,doc,ruby_targets_",
     )
     if key := bugs_fetcher.read_api_key():
         args += (f'--api-key={key}', )


### PR DESCRIPTION
Without this, if binpkgs are used via EMERGE_DEFAULT_OPTS or FEATURES, we can't properly pick up test deps and we get stuck on e.g. circular deps.

Bug: https://bugs.gentoo.org/639588