### PR TITLE
pkgdev.tatt.template.sh: optimize --usepkg=n hack a little bit

### DIFF
--- a/pkgdev.tatt.template.sh
+++ b/pkgdev.tatt.template.sh
@@ -86,16 +86,16 @@ tatt_test_pkg() {
         EMERGE_OUTPUT=/dev/tty
     fi
 
+    # We run some emerge commands twice here with --usepkg=n because of a
+    # --with-test-deps quirk (bug #639588).
     if [[ ${2} == "--test" ]]; then
         # Do a first pass to avoid circular dependencies
         # --onlydeps should mean we're avoiding (too much) duplicate work
-        USE="minimal -doc" tattoo_emerge "${1}" --onlydeps --quiet --oneshot --with-test-deps
-        # Run it again with --usepkg=n because of a --with-test-deps quirk (bug #639588)
-        USE="minimal -doc" tattoo_emerge "${1}" --onlydeps --quiet --oneshot --with-test-deps --usepkg=n
+        USE="minimal -doc" tattoo_emerge "${1}" --onlydeps --quiet --oneshot --with-test-deps || \
+               USE="minimal -doc" tattoo_emerge "${1}" --onlydeps --quiet --oneshot --with-test-deps --usepkg=n
 
-        tattoo_emerge "${1}" --onlydeps --quiet --oneshot --with-test-deps
-        # Run it again with --usepkg=n because of a --with-test-deps quirk (bug #639588)
-        if ! tattoo_emerge "${1}" --onlydeps --quiet --oneshot --with-test-deps --usepkg=n; then
+        if ! tattoo_emerge "${1}" --onlydeps --quiet --oneshot --with-test-deps && \
+		! tattoo_emerge "${1}" --onlydeps --quiet --oneshot --with-test-deps --usepkg=n; then
             tatt_json_report_error "merging test dependencies failed"
             return 1
         fi


### PR DESCRIPTION
Followup to 3fba48757fea89eb30ac846d9564962fb8a2be90.

Arthur mentioned on the review of the initial commit [0] that it's a shame to have to do this because all emerge invocations are expensive on some machines.

Optmize by:
1) only doing the minimal build again if the first one fails (this should be fine
   as the USE="minimal -doc" case probably isn't going to cover much the next one
   won't anyway).
2) not running the second general emerge again if the first one fails.

[0] https://github.com/arthurzam/tattoo/pull/6#pullrequestreview-1939139207

Ultimately though, we just need to fix bug #639588.

Bug: https://bugs.gentoo.org/639588