### PR TITLE
profiles/package.use.mask: mask USE=build

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ was kind enough to decide on the name "tattoo", which came from combining
     arch=arm64
     emergeopts="--autounmask --autounmask-continue --autounmask-write"
     repodir="/var/db/repos/gentoo/"
-    ignoreprefix="elibc_","video_cards_","linguas_","python_targets_","python_single_target_","kdeenablefinal","test","debug","qemu_user_","qemu_softmmu_","libressl","static-libs","systemd","sdjournal","eloginid","doc","ruby_targets_"
+    ignoreprefix="elibc_","video_cards_","linguas_","python_targets_","python_single_target_","kdeenablefinal","test","debug","qemu_user_","qemu_softmmu_","libressl","static-libs","systemd","sdjournal","elogin","doc","ruby_targets_"
     buildlogdir=/root/logs
     rdeps=0
     usecombis=1

--- a/profile/package.use.mask
+++ b/profile/package.use.mask
@@ -1,6 +1,7 @@
 dev-haskell/* profile
 dev-lang/perl ithreads minimal
 dev-lang/rust lto
+sys-devel/clang-common default-libcxx
 sys-libs/binutils-libs 64-bit-bfd
 */* build
 */* bootstrap

--- a/profile/package.use.mask
+++ b/profile/package.use.mask
@@ -3,3 +3,4 @@ dev-lang/perl ithreads minimal
 dev-lang/rust lto
 */* build
 */* bootstrap
+*/* vanilla

--- a/profile/package.use.mask
+++ b/profile/package.use.mask
@@ -1,4 +1,5 @@
 dev-haskell/* profile
 dev-lang/perl ithreads minimal
 dev-lang/rust lto
+*/* build
 */* bootstrap

--- a/profile/package.use.mask
+++ b/profile/package.use.mask
@@ -3,6 +3,7 @@ dev-lang/perl ithreads minimal
 dev-lang/rust lto
 sys-devel/clang-common default-libcxx
 sys-libs/binutils-libs 64-bit-bfd
+sys-libs/glibc headers-only
 */* build
 */* bootstrap
 */* vanilla

--- a/profile/package.use.mask
+++ b/profile/package.use.mask
@@ -6,4 +6,5 @@ sys-libs/binutils-libs 64-bit-bfd
 sys-libs/glibc headers-only
 */* build
 */* bootstrap
+*/* debug
 */* vanilla

--- a/profile/package.use.mask
+++ b/profile/package.use.mask
@@ -1,6 +1,7 @@
 dev-haskell/* profile
 dev-lang/perl ithreads minimal
 dev-lang/rust lto
+sys-libs/binutils-libs 64-bit-bfd
 */* build
 */* bootstrap
 */* vanilla

--- a/tester.py
+++ b/tester.py
@@ -99,7 +99,7 @@ async def test_run(writer: Callable[[Any], Any], bug_no: int) -> str:
         f'--template-file={pkgdev_template}',
         f"--logs-dir={str(logs_dir)}",
         "--emerge-opts=--autounmask-keep-keywords=y --autounmask-use=y --autounmask-continue --autounmask-write",
-        "--ignore-prefixes=elibc_,video_cards_,linguas_,python_targets_,python_single_target_,kdeenablefinal,test,debug,qemu_user_,qemu_softmmu_,libressl,static-libs,systemd,sdjournal,elogind,doc,ruby_targets_,default-libcxx",
+        "--ignore-prefixes=elibc_,video_cards_,linguas_,python_targets_,python_single_target_,kdeenablefinal,test,debug,qemu_user_,qemu_softmmu_,libressl,static-libs,systemd,sdjournal,elogind,doc,ruby_targets_,default-libcxx,headers-only",
     )
     if key := bugs_fetcher.read_api_key():
         args += (f'--api-key={key}', )


### PR DESCRIPTION
This is a dangerous USE flag which is used just by releng for catalyst/bootstrapping.

Signed-off-by: Sam James <sam@gentoo.org>